### PR TITLE
Make compatible with Salt 2019.2.0

### DIFF
--- a/grafana/server.sls
+++ b/grafana/server.sls
@@ -3,7 +3,7 @@
 
 grafana_packages:
   pkg.installed:
-  - names: {{ server.pkgs }}
+  - names: {{ server.pkgs|tojson }}
 
 /etc/grafana/grafana.ini:
   file.managed:


### PR DESCRIPTION
I couldn't install this formula on Salt 2019.2.0. Turns out, something has changed in regards to how the `names` in `pkg.installed` is being used, see [Salt Issue #51925](https://github.com/saltstack/salt/issues/51925).

This PR implements this specific change in order to make the formula functional again.