### PR TITLE
Add (optional) repo to be used

### DIFF
--- a/grafana/repo.sls
+++ b/grafana/repo.sls
@@ -1,0 +1,7 @@
+# Adds the Grafana repo
+grafana_repo:
+  pkgrepo.managed:
+    - name: deb https://packages.grafana.com/oss/deb stable main
+    - key_url: https://packages.grafana.com/gpg.key
+    - require_in:
+      - pkg: grafana_packages


### PR DESCRIPTION
This formula isn't self-contained since it relies on other formulas to manage the repo. 
To me, this doesn't make sense and IMHO formulas should always be separate from others unless there are very specific use-cases for this.

This PR adds an optional repo file which can be included for those who don't want to use other formulas to manage their package repo's with.